### PR TITLE
Remove double title

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,10 +6,6 @@
 		<main id="main" class="site-main" role="main">
 
 		<article class="post">
-			<h2 class="entry-title">
-				<a href="{{ .Permalink }}" rel="bookmark" data-slimstat="5">{{ .Title }}</a>
-
-			</h2>
 			<aside class="entry-meta lined-title">
 				<time class="entry-date published"  class="content-subhead">{{ .Date.Format "02 Jan 2006, 15:04" }}</time>
 			</aside>


### PR DESCRIPTION
Its totaly unnessesary in the single pages,
Example:
http://marcusfolkesson.se/blog/beer2rst/

